### PR TITLE
SRFINTE-2954: Sonar over Gradle + Test Result Publication

### DIFF
--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -60,8 +60,9 @@ jobs:
       with:
         artifact: test-results
         name: Test Results
-        path: '**/build/test-results/test/*.xml'
         reporter: java-junit
+        path: '*.xml'
+        fail-on-error: false
 
     - name: Sonar (with test coverage)
       if: inputs.skipJacocoReport == false

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -28,6 +28,10 @@ on:
         type: string
         default: "dockerPush"
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   gradle-build-test:
     runs-on: ubuntu-latest
@@ -58,17 +62,13 @@ jobs:
 
     - name: Sonar (with test coverage)
       if: inputs.skipJacocoReport == false
-      run: ./gradlew sonar -Pcoverage
-      permissions:
-        pull-requests: read
+      run: ./gradlew sonar -Pcoverage --info
       env:
         SONAR_TOKEN: ${{ secrets.INTE_SONAR_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Sonar (without test coverage)
       if: inputs.skipJacocoReport == true
-      run: ./gradlew sonar
-      permissions:
-        pull-requests: read
+      run: ./gradlew sonar --info
       env:
         SONAR_TOKEN: ${{ secrets.INTE_SONAR_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -46,13 +46,8 @@ jobs:
         cache: 'gradle'
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
-    - name: Setup Cache for SonarCloud
-      uses: actions/cache@v3
-      with:
-        path: ~/.sonar/cache
-        key: ${{ runner.os }}-sonar
-        restore-keys: ${{ runner.os }}-sonar
 
+    ## Build
     - name: Build, test & code coverage
       if: inputs.testCoverage == true
       run: ./gradlew ${{ inputs.gradleBuildTasks }} jacocoTestReport
@@ -68,6 +63,13 @@ jobs:
           **/test-results/**/*.trx
           **/test-results/**/*.json
 
+    ## Sonar
+    - name: Setup Cache for SonarCloud
+      uses: actions/cache@v3
+      with:
+        path: ~/.sonar/cache
+        key: ${{ runner.os }}-sonar
+        restore-keys: ${{ runner.os }}-sonar
     - name: Sonar (with test coverage)
       if: inputs.testCoverage == true
       run: ./gradlew sonar -Pcoverage --info
@@ -81,6 +83,7 @@ jobs:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    ## Publishing
     - name: Publish jar
       if: startsWith(github.ref, 'refs/tags/') && inputs.publishJar
       run: ./gradlew ${{ inputs.gradlePublishJarTasks }}

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -58,10 +58,11 @@ jobs:
 
     - uses: EnricoMi/publish-unit-test-result-action@v2
       with:
+        comment_mode: failures
         files: |
-          test-results/**/*.xml
-          test-results/**/*.trx
-          test-results/**/*.json
+          **/test-results/**/*.xml
+          **/test-results/**/*.trx
+          **/test-results/**/*.json
 
     - name: Sonar (with test coverage)
       if: inputs.skipJacocoReport == false

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -56,13 +56,12 @@ jobs:
       if: inputs.skipJacocoReport == true
       run: ./gradlew ${{ inputs.gradleBuildTasksSkipCoverage }}
 
-    - uses: dorny/test-reporter@v1
+    - uses: EnricoMi/publish-unit-test-result-action@v2
       with:
-        artifact: test-results
-        name: Test Results
-        reporter: java-junit
-        path: '*.xml'
-        fail-on-error: false
+        files: |
+          test-results/**/*.xml
+          test-results/**/*.trx
+          test-results/**/*.json
 
     - name: Sonar (with test coverage)
       if: inputs.skipJacocoReport == false

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         artifact: test-results
         name: Test Results
-        path: 'build/test-results/test/*.xml'
+        path: '**/build/test-results/test/*.xml'
         reporter: java-junit
 
     - name: Sonar (with test coverage)

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -28,10 +28,6 @@ on:
         type: string
         default: "dockerPush"
 
-permissions:
-  contents: read
-  pull-requests: read
-
 jobs:
   gradle-build-test:
     runs-on: ubuntu-latest
@@ -60,17 +56,24 @@ jobs:
       if: inputs.skipJacocoReport == true
       run: ./gradlew ${{ inputs.gradleBuildTasksSkipCoverage }}
 
+    - uses: dorny/test-reporter@v1
+      with:
+        artifact: test-results
+        name: Test Results
+        path: 'build/test-results/test/*.xml'
+        reporter: java-junit
+
     - name: Sonar (with test coverage)
       if: inputs.skipJacocoReport == false
       run: ./gradlew sonar -Pcoverage --info
       env:
-        SONAR_TOKEN: ${{ secrets.INTE_SONAR_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Sonar (without test coverage)
       if: inputs.skipJacocoReport == true
       run: ./gradlew sonar --info
       env:
-        SONAR_TOKEN: ${{ secrets.INTE_SONAR_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     #- name: SonarQube Scan

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -9,18 +9,15 @@ on:
       createContainer:
         type: boolean
         default: false
-      skipJacocoReport:
+      testCoverage:
         type: boolean
-        default: false
+        default: true
       javaVersion:
         type: number
         default: 17
       gradleBuildTasks:
         type: string
-        default: "clean build test jacocoTestReport --info"
-      gradleBuildTasksSkipCoverage:
-        type: string
-        default: "clean build test --info"
+        default: "--info clean build test --info"
       gradlePublishJarTasks:
         type: string
         default: "publish"
@@ -50,11 +47,11 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Build, test & code coverage
-      if: inputs.skipJacocoReport == false
-      run: ./gradlew ${{ inputs.gradleBuildTasks }}
+      if: inputs.testCoverage == true
+      run: ./gradlew ${{ inputs.gradleBuildTasks }} jacocoTestReport
     - name: Build, test without code coverage
-      if: inputs.skipJacocoReport == true
-      run: ./gradlew ${{ inputs.gradleBuildTasksSkipCoverage }}
+      if: inputs.testCoverage == false
+      run: ./gradlew ${{ inputs.gradleBuildTasks }}
 
     - uses: EnricoMi/publish-unit-test-result-action@v2
       with:
@@ -65,23 +62,17 @@ jobs:
           **/test-results/**/*.json
 
     - name: Sonar (with test coverage)
-      if: inputs.skipJacocoReport == false
+      if: inputs.testCoverage == true
       run: ./gradlew sonar -Pcoverage --info
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Sonar (without test coverage)
-      if: inputs.skipJacocoReport == true
+      if: inputs.testCoverage == false
       run: ./gradlew sonar --info
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    #- name: SonarQube Scan
-    #  uses: sonarsource/sonarqube-scan-action@master
-    #  env:
-    #    SONAR_HOST_URL: https://sonarcloud.io
-    #    SONAR_TOKEN: ${{ secrets.INTE_SONAR_TOKEN }}
 
     - name: Publish jar
       if: startsWith(github.ref, 'refs/tags/') && inputs.publishJar

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -59,12 +59,16 @@ jobs:
     - name: Sonar (with test coverage)
       if: inputs.skipJacocoReport == false
       run: ./gradlew sonar -Pcoverage
+      permissions:
+        pull-requests: read
       env:
         SONAR_TOKEN: ${{ secrets.INTE_SONAR_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Sonar (without test coverage)
       if: inputs.skipJacocoReport == true
       run: ./gradlew sonar
+      permissions:
+        pull-requests: read
       env:
         SONAR_TOKEN: ${{ secrets.INTE_SONAR_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -56,11 +56,24 @@ jobs:
       if: inputs.skipJacocoReport == true
       run: ./gradlew ${{ inputs.gradleBuildTasksSkipCoverage }}
 
-    - name: SonarQube Scan
-      uses: sonarsource/sonarqube-scan-action@master
+    - name: Sonar (with test coverage)
+      if: inputs.skipJacocoReport == false
+      run: ./gradlew sonar -Pcoverage
       env:
-        SONAR_HOST_URL: https://sonarcloud.io
         SONAR_TOKEN: ${{ secrets.INTE_SONAR_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Sonar (without test coverage)
+      if: inputs.skipJacocoReport == true
+      run: ./gradlew sonar
+      env:
+        SONAR_TOKEN: ${{ secrets.INTE_SONAR_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    #- name: SonarQube Scan
+    #  uses: sonarsource/sonarqube-scan-action@master
+    #  env:
+    #    SONAR_HOST_URL: https://sonarcloud.io
+    #    SONAR_TOKEN: ${{ secrets.INTE_SONAR_TOKEN }}
 
     - name: Publish jar
       if: startsWith(github.ref, 'refs/tags/') && inputs.publishJar

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -17,7 +17,7 @@ on:
         default: 17
       gradleBuildTasks:
         type: string
-        default: "--info clean build test --info"
+        default: "--info clean build test"
       gradlePublishJarTasks:
         type: string
         default: "publish"


### PR DESCRIPTION
Migration auf neue SonarCloud-Organisation war nötig... Muss ich bei allen Projekten noch umstellen.

Beispiele für die Reports:
* Mit Coverage: https://github.com/mmz-srf/inte.srv.audioprocessing/pull/3
* Ohne Coverage: https://github.com/mmz-srf/inte.srv.fileoperation.model/pull/2