### PR TITLE
Simplify Coverage

### DIFF
--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -9,9 +9,6 @@ on:
       createContainer:
         type: boolean
         default: false
-      testCoverage:
-        type: boolean
-        default: true
       javaVersion:
         type: number
         default: 17
@@ -66,15 +63,8 @@ jobs:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
-    - name: Sonar (with test coverage)
-      if: inputs.testCoverage == true
+    - name: Sonar
       run: ./gradlew sonar -Pcoverage --info
-      env:
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Sonar (without test coverage)
-      if: inputs.testCoverage == false
-      run: ./gradlew sonar --info
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -48,11 +48,7 @@ jobs:
       uses: gradle/gradle-build-action@v2
 
     ## Build
-    - name: Build, test & code coverage
-      if: inputs.testCoverage == true
-      run: ./gradlew ${{ inputs.gradleBuildTasks }} jacocoTestReport
-    - name: Build, test without code coverage
-      if: inputs.testCoverage == false
+    - name: Build & Test
       run: ./gradlew ${{ inputs.gradleBuildTasks }}
 
     - uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
* Jacoco sollte in der Verantwortung der Projekte sein: Werde ich überall wo nötig als finalize-Schritt im Test-Target dazunehmen. Beispiel hier: https://github.com/mmz-srf/inte.srv.archive/compare/feature/jacoco-improvements
* Coverage bei Sonar darf auch aktiv sein, wenn kein jacoco-Plugin registriert ist. Seitens Sonar klappt das und damit haben wir einen Parameter in der Pipeline weniger